### PR TITLE
Adding base framework

### DIFF
--- a/simplifier/simplifier.ml
+++ b/simplifier/simplifier.ml
@@ -102,9 +102,25 @@ let process_conjunctions (p : SHpure.t) : SHpure.t =
   match p with
   | And conjunctions ->
       let g = WDGraph.create () in
+
+      let start_time_build = Unix.gettimeofday () in
       let _ = WDGraph.add_conjunctions g conjunctions in 
+      let end_time_build = Unix.gettimeofday () in
+      let elapsed_time_build = end_time_build -. start_time_build in
+      Printf.printf "Execution time build graph: %f seconds\n" elapsed_time_build;
+
+      let start_time_simplify = Unix.gettimeofday () in
       let _ = WDGraph.simplify g in 
+      let end_time_simplify = Unix.gettimeofday () in
+      let elapsed_time_simplify = end_time_simplify -. start_time_simplify in
+      Printf.printf "Execution time simplify graph: %f seconds\n" elapsed_time_simplify;
+
+      let start_time_rebuild = Unix.gettimeofday () in
       let simplified_conjunctions = WDGraph.get_conjunctions g in 
+      let end_time_rebuild = Unix.gettimeofday () in
+      let elapsed_time_rebuild = end_time_rebuild -. start_time_rebuild in
+      Printf.printf "Execution time re-build graph: %f seconds\n" elapsed_time_rebuild;
+
       And simplified_conjunctions
   | _ ->
       failwith "ERROR: Unexpected formula structure during process_conjunctions. Expected: And"
@@ -112,7 +128,11 @@ let process_conjunctions (p : SHpure.t) : SHpure.t =
 
 (* Currently do nothing *)
 let simplify_pure (p : SHpure.t) : SHpure.t =
+  let start_time_dnf = Unix.gettimeofday () in
   let dnf_p = to_dnf p in
+  let end_time_dnf = Unix.gettimeofday () in
+  let elapsed_time_dnf = end_time_dnf -. start_time_dnf in
+  Printf.printf "Execution time DNF conversion: %f seconds\n" elapsed_time_dnf;
   match dnf_p with
   | Or clauses -> Or (List.map process_conjunctions clauses)
   | And _ -> process_conjunctions dnf_p

--- a/simplifier/simplifier.ml
+++ b/simplifier/simplifier.ml
@@ -98,7 +98,7 @@ let to_dnf (p: SHpure.t) : SHpure.t =
   (*|> SHpure.syntactical_simplL   (* Simplify resulting formula *)
   |> SHpure.extinguish_phantoms  (* Remove phantom variables *)*)
 
-let process_conjunctions (p : SHpure.t) : SHpure.t =
+let process_conjunctions (p : SHpure.t) (_stats : bool) : SHpure.t =
   match p with
   | And conjunctions ->
       let g = WDGraph.create () in
@@ -107,19 +107,22 @@ let process_conjunctions (p : SHpure.t) : SHpure.t =
       let _ = WDGraph.add_conjunctions g conjunctions in 
       let end_time_build = Unix.gettimeofday () in
       let elapsed_time_build = end_time_build -. start_time_build in
-      Printf.printf "Execution time build graph: %f seconds\n" elapsed_time_build;
+      if _stats then
+        Printf.printf "Execution time build graph: %f seconds\n" elapsed_time_build;
 
       let start_time_simplify = Unix.gettimeofday () in
       let _ = WDGraph.simplify g in 
       let end_time_simplify = Unix.gettimeofday () in
       let elapsed_time_simplify = end_time_simplify -. start_time_simplify in
-      Printf.printf "Execution time simplify graph: %f seconds\n" elapsed_time_simplify;
+      if _stats then
+        Printf.printf "Execution time simplify graph: %f seconds\n" elapsed_time_simplify;
 
       let start_time_rebuild = Unix.gettimeofday () in
       let simplified_conjunctions = WDGraph.get_conjunctions g in 
       let end_time_rebuild = Unix.gettimeofday () in
       let elapsed_time_rebuild = end_time_rebuild -. start_time_rebuild in
-      Printf.printf "Execution time re-build graph: %f seconds\n" elapsed_time_rebuild;
+      if _stats then
+        Printf.printf "Execution time re-build graph: %f seconds\n" elapsed_time_rebuild;
 
       And simplified_conjunctions
   | _ ->
@@ -127,15 +130,16 @@ let process_conjunctions (p : SHpure.t) : SHpure.t =
 
 
 (* Currently do nothing *)
-let simplify_pure (p : SHpure.t) : SHpure.t =
+let simplify_pure (p : SHpure.t) (_stats : bool) : SHpure.t =
   let start_time_dnf = Unix.gettimeofday () in
   let dnf_p = to_dnf p in
   let end_time_dnf = Unix.gettimeofday () in
   let elapsed_time_dnf = end_time_dnf -. start_time_dnf in
-  Printf.printf "Execution time DNF conversion: %f seconds\n" elapsed_time_dnf;
+  if _stats then
+    Printf.printf "Execution time DNF conversion: %f seconds\n" elapsed_time_dnf;
   match dnf_p with
-  | Or clauses -> Or (List.map process_conjunctions clauses)
-  | And _ -> process_conjunctions dnf_p
+  | Or clauses -> Or (List.map (fun clause -> process_conjunctions clause _stats) clauses)
+  | And _ -> process_conjunctions dnf_p _stats
   | _ -> dnf_p
   
 ;;

--- a/simplifier/simplifier_main.ml
+++ b/simplifier/simplifier_main.ml
@@ -37,6 +37,7 @@ let _modelflag = ref false;;
 let _ucflag = ref false;;
 let _bnflag = ref false;;
 let _timeout = ref None;;
+let _stats= ref false;;
 let f_help () = print_endline "help";;
 let set_filename fname = _fname := fname;;
 let set_raw () = _rawflag := true;;
@@ -44,9 +45,10 @@ let set_model () = _modelflag := true;;
 let set_unsatcore () = _ucflag := true;;
 let set_foption opt = p_opt := opt :: !p_opt;;
 let set_timeout sec = _timeout := Some sec;;
+let set_stats () = _stats := true;;
   
 let msgUsage =
-"USAGE: simplifier [-d <TAG>|-b|-0|-t] -f <filename>";;
+"USAGE: simplifier [-d <TAG>|-b|-0|-t|-s] -f <filename>";;
 
 let speclist = [
     ("-f", Arg.String set_filename, "Input file (mandatory)");
@@ -57,6 +59,7 @@ let speclist = [
       MD: produce & show a model when an input is sat");
     ("-0", Arg.Unit set_raw, "Use raw z3 (Only checking the pure-part with Z3 ignoring the spat-part)");
     ("-t", Arg.Int set_timeout, "Set timeout [sec] (default:4294967295)");
+    ("-s", Arg.Unit set_stats, "Reports execution stats (execution time for now)");
   ];;
 
 (* parser *)
@@ -79,7 +82,7 @@ let () =
   Fmt.printf "@[[Spatial-formula]@.";
   Fmt.printf "@[%a@." SS.pp ss;
 
-  let p' = Simplifier.simplify_pure p in 
+  let p' = Simplifier.simplify_pure p !_stats in 
     
   Fmt.printf "@[[Simplified Pure-formula]@.";
   Fmt.printf "@[%a@." P.pp p';

--- a/simplifier/simplifier_main.ml
+++ b/simplifier/simplifier_main.ml
@@ -69,7 +69,11 @@ let () =
   Arg.parse speclist print_endline msgUsage;
   let check_fname () = if !_fname = "" then (display_message (); exit 0) else () in
   check_fname();
+  let start_time_parse = Unix.gettimeofday () in
   let (p,ss) = parse (inputstr_file !_fname) in
+  let end_time_parse = Unix.gettimeofday () in
+  let elapsed_time_parse = end_time_parse -. start_time_parse in
+  Printf.printf "Execution time: %f seconds\n" elapsed_time_parse;
   Fmt.printf "@[[Pure-formula]@.";
   Fmt.printf "@[%a@." P.pp p;  
   Fmt.printf "@[[Spatial-formula]@.";
@@ -83,17 +87,17 @@ let () =
   let g = WDGraph.create () in
 
   (* Dynamically add edges (nodes are automatically added) *)
-  let _ = WDGraph.add_edge g 0 1 1 in
-  let _ = WDGraph.add_edge g 0 1 1 in
-  let _ = WDGraph.add_edge g 2 2 0 in
-  let _ = WDGraph.add_edge g 2 3 1 in
-  let _ = WDGraph.add_edge g 2 3 0 in
-  let _ = WDGraph.add_edge g 3 0 2 in
-  let _ = WDGraph.add_edge g 3 0 1 in
+  let _ = WDGraph.add_edge g (Slsyntax.SHterm.Int 0) (Slsyntax.SHterm.Int 1) 1 in
+  let _ = WDGraph.add_edge g (Slsyntax.SHterm.Int 0) (Slsyntax.SHterm.Int 1) 1 in
+  let _ = WDGraph.add_edge g (Slsyntax.SHterm.Int 2) (Slsyntax.SHterm.Int 2) 0 in
+  let _ = WDGraph.add_edge g (Slsyntax.SHterm.Int 2) (Slsyntax.SHterm.Int 3) 1 in
+  let _ = WDGraph.add_edge g (Slsyntax.SHterm.Int 2) (Slsyntax.SHterm.Int 3) 0 in
+  let _ = WDGraph.add_edge g (Slsyntax.SHterm.Int 3) (Slsyntax.SHterm.Int 0) 2 in
+  let _ = WDGraph.add_edge g (Slsyntax.SHterm.Int 3) (Slsyntax.SHterm.Int 0) 1 in
 
   (* Traverse edges *)
   let edges = WDGraph.traverse_edges g in
-  List.iter (fun (u, v, w) ->
+  List.iter (fun (Slsyntax.SHterm.Int u, Slsyntax.SHterm.Int v, w) ->
       Printf.printf "Edge: %d -> %d (Weight: %d)\n"  u v w
     ) edges;
   

--- a/simplifier/wdgraph/wdg.ml
+++ b/simplifier/wdgraph/wdg.ml
@@ -1,4 +1,5 @@
 open Graph
+open Slsyntax
 
 (* Define the graph module using OCamlgraph's Persistent.Digraph.ConcreteLabeled functor *)
 module WDGraph = struct
@@ -69,5 +70,10 @@ module WDGraph = struct
         let pc = Path.create(g.graph) in
         Path.check_path pc v u
       ) g.red_edges
+  
+  (*Place holders, maye all the pre and post should be in another module so this class/module doesnt have to import Slsyntax*)
+  let add_conjunctions (g : t) (conjunctions) : unit = Printf.printf "Entering `add_conjunctions`.\n"
+  let simplify (g : t) : unit = Printf.printf "Entering `simplify`.\n"
+  let get_conjunctions (g : t) : Slsyntax.SHpure.t list = Printf.printf "Entering `get_conjunctions`.\n"; [True]
 end
 

--- a/simplifier/wdgraph/wdg.ml
+++ b/simplifier/wdgraph/wdg.ml
@@ -5,7 +5,7 @@ open Slsyntax
 module WDGraph = struct
   (* Define a custom graph with integer nodes and edges labeled with weights *)
   module G = Persistent.Digraph.ConcreteLabeled(struct
-    type t = int
+    type t = Slsyntax.SHterm.t  (*Using terms as nodes*)
     let compare = compare
     let hash = Hashtbl.hash
     let equal = (=)
@@ -18,49 +18,51 @@ module WDGraph = struct
   (* Define a record type for the graph structure *)
   type t = {
     mutable graph : G.t;                  (* The OCamlgraph graph *)
-    mutable red_edges : (int * int) list;  (* List of edges with weight 0 *)
+    mutable red_edges : (Slsyntax.SHterm.t * Slsyntax.SHterm.t) list; (* List of edges with weight 0 *)
+    mutable unsat : bool;                 (* Indicates if the graph has become unsat or not *)
   }
 
   (* Initialize an empty graph structure *)
   let create () : t = {
     graph = G.empty;
     red_edges = [];
+    unsat = false;
   }
 
-  (* Add an edge to the graph with the new functionality *)
-  let add_edge (g : t) (u : int) (v : int) (w : int) : unit =
-    (* Check if both nodes exist in the variable_mapping *)
-    if G.mem_vertex g.graph u && G.mem_vertex g.graph v then begin
-      (* Check if there is an existing edge between u and v *)
-      try
-        let edge = G.find_edge g.graph u v in
-        match edge with
-        | (_,w',_) ->
-          if w <> w' then
-            (* Update the weight to 0 if the weights differ *)
-            let g' = G.remove_edge_e g.graph (u, w', v) in
-            let g' = G.add_edge_e g' (u, 0, v) in
-            g.graph <- g';
-            g.red_edges <- (u, v) :: g.red_edges
-          else
-            (* Edge exists with the same weight, do nothing *)
-            ()
-      with Not_found ->
-        (* If no edge exists, simply add it *)
-        let g' = G.add_edge_e g.graph (u, w, v) in
+  (* Add an edge to the graph. #TODO:Maybe can be shortened removing the 3rd if statement *)
+  let add_edge (g : t) (u : Slsyntax.SHterm.t) (v : Slsyntax.SHterm.t) (w : int) : unit =
+    if w = (-1) && u = v then g.unsat <- true; (* Black contradiction *)
+    if not (g.unsat) then
+      (* Check if both nodes exist in the variable_mapping *)
+      if G.mem_vertex g.graph u && G.mem_vertex g.graph v then begin
+        (* Check if there is an existing edge between u and v *)
+        try
+          let edge = G.find_edge g.graph u v in
+          match edge with
+          | (_,w',_) ->
+            if w <> w' then
+              (* Update the weight to 0 if the weights differ *)
+              let g' = G.remove_edge_e g.graph (u, w', v) in
+              let g' = G.add_edge_e g' (u, 0, v) in
+              g.graph <- g';
+              g.red_edges <- (u, v) :: g.red_edges;
+
+        with Not_found ->
+          (* If no edge exists, simply add it *)
+          let g' = G.add_edge_e g.graph (u, w, v) in
+          g.graph <- g';
+          if w = 0 then g.red_edges <- (u, v) :: g.red_edges
+        end
+      else
+        (* Add the nodes if they don't exist *)
+        let g' = G.add_vertex (G.add_vertex g.graph u) v in
+        let g' = G.add_edge_e g' (u, w, v) in
         g.graph <- g';
+        (* Add to red_edges if the weight is 0 *)
         if w = 0 then g.red_edges <- (u, v) :: g.red_edges
-      end
-    else
-      (* Add the nodes if they don't exist *)
-      let g' = G.add_vertex (G.add_vertex g.graph u) v in
-      let g' = G.add_edge_e g' (u, w, v) in
-      g.graph <- g';
-      (* Add to red_edges if the weight is 0 *)
-      if w = 0 then g.red_edges <- (u, v) :: g.red_edges
 
   (* Traverse all edges and return a list of (source, target, weight) *)
-  let traverse_edges (g : t) : (int * int * int) list =
+  let traverse_edges (g : t) : (Slsyntax.SHterm.t * Slsyntax.SHterm.t * int) list =
     G.fold_edges_e (fun (u, w, v) acc -> (u, v, w) :: acc) g.graph []
 
   (* Check if any of the red edges forms a cycle *)
@@ -70,10 +72,49 @@ module WDGraph = struct
         let pc = Path.create(g.graph) in
         Path.check_path pc v u
       ) g.red_edges
+
+  (* Preprocess an Atom s.t. its terms are minimal, i.e. reducing and evaluating all possible exoresions. #TODO:This might be better to do it while transforing formula to dnf *)
+  let preprocess_atom (a : Slsyntax.SHpure.t) : Slsyntax.SHpure.t = a (* #FIXME:Missing implementation *)
   
-  (*Place holders, maye all the pre and post should be in another module so this class/module doesnt have to import Slsyntax*)
-  let add_conjunctions (g : t) (conjunctions) : unit = Printf.printf "Entering `add_conjunctions`.\n"
-  let simplify (g : t) : unit = Printf.printf "Entering `simplify`.\n"
-  let get_conjunctions (g : t) : Slsyntax.SHpure.t list = Printf.printf "Entering `get_conjunctions`.\n"; [True]
+  (* Given a list of Atoms (conjunction of them) extract the terms and type of edge and add it to the graph *)
+  let add_conjunctions (g : t) (atoms : Slsyntax.SHpure.t list): unit = 
+      List.iter (fun a ->
+        if not (g.unsat) then
+          match a with
+          | Slsyntax.SHpure.False -> g.unsat <- true;
+          | Slsyntax.SHpure.Atom (op, tt) ->
+            let a' = preprocess_atom a in
+            match a' with
+            | Slsyntax.SHpure.Atom (op, tt) ->
+              let t0 = List.nth tt 0 in
+              let t1 = List.nth tt 1 in
+                match op with
+                | Eq -> 
+                    add_edge g t0 t1 1;
+                    add_edge g t1 t0 1;
+                | Neq -> 
+                    add_edge g t0 t1 (-1);
+                | Le -> add_edge g t0 t1 1;
+                | Lt -> add_edge g t0 t1 0;
+        ) atoms
+
+  (* Simplify the graph, i.e. post-analyssis of diferent properties *)
+  let simplify (g : t) : unit = 
+    if not (g.unsat) then
+      Printf.printf "Entering `simplify`.\n" (* #FIXME: Missing implementation *)
+  
+  (* Given a graph extract the terms and type of relation from edge and return a new conjunction list (all elements will be Atoms) *)
+  let get_conjunctions (g : t) : Slsyntax.SHpure.t list = 
+    if g.unsat then 
+      [False]
+    else 
+      let edges = traverse_edges g in
+      List.map (fun (u, v, w) ->
+        match w with
+        | (-1) -> Slsyntax.SHpure.Atom(Neq, [u; v])
+        | 0 -> Slsyntax.SHpure.Atom(Lt, [u; v])
+        | 1 -> Slsyntax.SHpure.Atom(Le, [u; v])
+        | _ -> failwith "Unexpected weight value"
+      ) edges
 end
 

--- a/simplifier/wdgraph/wdg.ml
+++ b/simplifier/wdgraph/wdg.ml
@@ -40,7 +40,7 @@ module WDGraph = struct
           let edge = G.find_edge g.graph u v in
           match edge with
           | (_,w',_) ->
-            if w <> w' then
+            if w <> w' then (* #TODO:Should check what happens when the u!=v is present and want to add v<u *)
               (* Update the weight to 0 if the weights differ *)
               let g' = G.remove_edge_e g.graph (u, w', v) in
               let g' = G.add_edge_e g' (u, 0, v) in


### PR DESCRIPTION
## General changes
On this PR we define a baseline for the main simplify algorithm in `wdg.ml` to be implemented in following PR's:
- Added `-s` (stats) flag to show execution time 
- Defined structure for `simplify_pure` as building phase, simplifying phase, and rebuilding phase.
- Added the necessary methods in the graph class to allow the previous division of phases.

## Minor changes
The vertices in the graph are now of type `Slsyntax.SHterm.t`.
Black edges are added in one direction only.

## Breakthrough of phases:
### Build
- Preprocess atoms: Preprocess the Atom's terms so that the terms are in minimal form and expresions with integers are evaluated ❌
- Add a list of Atoms to the graph: I.e. encoding each Atom in a conjuntion set into a graph ✅ 
- Create a set of independent graphs for every conjunction set ✅ 
### Simplify
- Check for contradictions: Red, Blue and Black contradictions  ❌
- Build SCC: Build SCCs, chose representative, build quotient graph ❌
### Rebuild
- Build formula from edges: Traverse all edges and return a list of new Atoms (i.e. new conjunction set) ✅ 
- Apply substitution to each node ❌ 