### PR TITLE
Simplify implementation

### DIFF
--- a/simplifier/simplifier.ml
+++ b/simplifier/simplifier.ml
@@ -109,7 +109,7 @@ let process_conjunctions (p : SHpure.t) (_stats : bool) : SHpure.t =
       let elapsed_time_build = end_time_build -. start_time_build in
       if _stats then
         Printf.printf "Execution time build graph: %f seconds\n" elapsed_time_build;
-
+      
       let start_time_simplify = Unix.gettimeofday () in
       let _ = WDGraph.simplify g in 
       let end_time_simplify = Unix.gettimeofday () in
@@ -125,9 +125,7 @@ let process_conjunctions (p : SHpure.t) (_stats : bool) : SHpure.t =
         Printf.printf "Execution time re-build graph: %f seconds\n" elapsed_time_rebuild;
 
       And simplified_conjunctions
-  | _ ->
-      failwith "ERROR: Unexpected formula structure during process_conjunctions. Expected: And"
-
+  | _ -> failwith "ERROR: Unexpected formula structure during process_conjunctions. Expected: And"
 
 (* Currently do nothing *)
 let simplify_pure (p : SHpure.t) (_stats : bool) : SHpure.t =

--- a/simplifier/simplifier_main.ml
+++ b/simplifier/simplifier_main.ml
@@ -86,28 +86,6 @@ let () =
     
   Fmt.printf "@[[Simplified Pure-formula]@.";
   Fmt.printf "@[%a@." P.pp p';
-
-  let g = WDGraph.create () in
-
-  (* Dynamically add edges (nodes are automatically added) *)
-  let _ = WDGraph.add_edge g (Slsyntax.SHterm.Int 0) (Slsyntax.SHterm.Int 1) 1 in
-  let _ = WDGraph.add_edge g (Slsyntax.SHterm.Int 0) (Slsyntax.SHterm.Int 1) 1 in
-  let _ = WDGraph.add_edge g (Slsyntax.SHterm.Int 2) (Slsyntax.SHterm.Int 2) 0 in
-  let _ = WDGraph.add_edge g (Slsyntax.SHterm.Int 2) (Slsyntax.SHterm.Int 3) 1 in
-  let _ = WDGraph.add_edge g (Slsyntax.SHterm.Int 2) (Slsyntax.SHterm.Int 3) 0 in
-  let _ = WDGraph.add_edge g (Slsyntax.SHterm.Int 3) (Slsyntax.SHterm.Int 0) 2 in
-  let _ = WDGraph.add_edge g (Slsyntax.SHterm.Int 3) (Slsyntax.SHterm.Int 0) 1 in
-
-  (* Traverse edges *)
-  let edges = WDGraph.traverse_edges g.graph in
-  List.iter (fun (Slsyntax.SHterm.Int u, Slsyntax.SHterm.Int v, w) ->
-      Printf.printf "Edge: %d -> %d (Weight: %d)\n"  u v w
-    ) edges;
-  
-  let red_cycle = WDGraph.forms_cycle_with_red g in
-    if red_cycle then
-    Printf.printf "Red cycle found\n";
-
   
 (*  
   let (startMesRaw,ssMes) = if !_rawflag then ("RAW-MODE ","Ignored") else ("","") in

--- a/simplifier/simplifier_main.ml
+++ b/simplifier/simplifier_main.ml
@@ -99,7 +99,7 @@ let () =
   let _ = WDGraph.add_edge g (Slsyntax.SHterm.Int 3) (Slsyntax.SHterm.Int 0) 1 in
 
   (* Traverse edges *)
-  let edges = WDGraph.traverse_edges g in
+  let edges = WDGraph.traverse_edges g.graph in
   List.iter (fun (Slsyntax.SHterm.Int u, Slsyntax.SHterm.Int v, w) ->
       Printf.printf "Edge: %d -> %d (Weight: %d)\n"  u v w
     ) edges;

--- a/simplifier/wdgraph/wdg.ml
+++ b/simplifier/wdgraph/wdg.ml
@@ -114,6 +114,9 @@ module WDGraph = struct
     !sub_g
   
   (* Preprocess an Atom s.t. its terms are minimal, i.e. reducing and evaluating all possible exoresions. #TODO:This might be better to do it while transforing formula to dnf *)
+  let preprocess_and_eval_atom (a : Slsyntax.SHpure.t) : Slsyntax.SHpure.t = a (* #FIXME:Missing implementation *)
+
+  (* Postprocess an Atom s.t. its terms are minimal, i.e. reducing and evaluating all possible exoresions. #TODO:This might be better to do it while transforing formula to dnf *)
   let postprocess_and_eval_atom (a : Slsyntax.SHpure.t) : Slsyntax.SHpure.t = a (* #FIXME:Missing implementation *)
   
   (* Given a list of Atoms (conjunction of them) extract the terms and type of edge and add it to the graph *)


### PR DESCRIPTION
## General changes
On this PR we implement the main simplify subroutine in `wdg.ml`.

## Minor changes
Format/refactor changes in other files.
Added new attributes to the `WDGraph` module such as scc information and membership funcions as well with quotient graph and representative function.

## Breakthrough of phases (current status):
### Build
- Preprocess atoms: Preprocess the Atom's terms and evaluate (after substitution) so that the terms are in minimal form ❌
- Add a list of Atoms to the graph: I.e. encoding each Atom in a conjuntion set into a graph ✅ 
- Create a set of independent graphs for every conjunction set ✅ 
### Simplify
- Check for contradictions: Red, Blue and Black contradictions  ✅ 
- Build SCC: Build SCCs, chose representative, build quotient graph ✅ 
### Rebuild
- Postprocess atoms: Postprocess the Atom's terms and evaluate (after substitution) so that the terms are in minimal form ❌
- Build formula from edges: Traverse all edges and return a list of new Atoms (i.e. new conjunction set) ✅ 