### PR TITLE
Partial simplification

### DIFF
--- a/simplifier/simplifier.ml
+++ b/simplifier/simplifier.ml
@@ -1,6 +1,7 @@
 (*
   Simplifier of Symbolic Heaps
 *)
+open Notations
 open Slsyntax
 open Wdg
 
@@ -184,10 +185,10 @@ let to_dnf (p: SHpure.t) : SHpure.t =
 
 let eval_atom (a : SHpure.t) : SHpure.t = 
   match a with
-  |Atom(Le, [Int x; Int y]) -> if x > y then False else a
-  |Atom(Lt, [Int x; Int y]) -> if x >= y then False else a
-  |Atom(Neq, [Int x; Int y]) -> if not (x != y) then False else a
-  |Atom(Eq, [Int x; Int y]) -> if x != y then False else a
+  |Atom(Le, [Int x; Int y]) -> if x > y then False else True
+  |Atom(Lt, [Int x; Int y]) -> if x >= y then False else True
+  |Atom(Neq, [Int x; Int y]) -> if not (x != y) then False else True
+  |Atom(Eq, [Int x; Int y]) -> if x != y then False else True
   |_ -> a
 
 let process_conjunctions (p : SHpure.t) (ptr_spat : (SHterm.t * (string * SHterm.t) list) list) (arr_spat : (SHterm.t * SHterm.t) list) (str_spat : (SHterm.t * SHterm.t) list) (_serialize : bool) (_print : bool) : SHpure.t * SHspat.t =
@@ -200,6 +201,8 @@ let process_conjunctions (p : SHpure.t) (ptr_spat : (SHterm.t * (string * SHterm
       let _ = WDGraph.add_mem_spat g arr_spat str_spat ptr_spat in (* IMPORTANT first add array over pointers, otherwise will be hard to check for cycles of yellow edges to detect backward edges (src memory addres > dst memory adress ) *)
       let _ = WDGraph.add_ptr g ptr_spat in
       if _serialize then (
+        Fmt.printf "@[[Partial subformula]@.";
+        Fmt.printf "@[%a@." SHpure.pp p; 
         let dot_g = DotSerializer.serialize_graph g in
         Printf.printf "\nDot serialize graph:\n";
         print_endline dot_g;
@@ -208,6 +211,8 @@ let process_conjunctions (p : SHpure.t) (ptr_spat : (SHterm.t * (string * SHterm
         print_endline dot_qg;
       );
       if _print then (
+        Fmt.printf "@[[Partial subformula]@.";
+        Fmt.printf "@[%a@." SHpure.pp p; 
         Printf.printf "Graph Summary:\n";
         TextPrinter.print_graph g;
         Printf.printf "Quotient Graph Summary:\n";
@@ -277,4 +282,77 @@ let simplify_pure_spat (p : SHpure.t) (ss : SHspat.t) (_stats : bool) (_serializ
     red_dnf_p
   | _ -> [(eval_atom dnf_p, [])]
   
+
+  let partial_preprocess (p: SHpure.t) : SHpure.t =
+    p
+    (*|> SHpure.unfold_indirect      (* Replace indirect references *)*)
+    |> remove_implications         (* Remove implications and biconditionals *)
+    |> push_negations              (* Push negations inward using dual *)
+    |> normalize_associativity    (* Normalize associativity of And/Or *)
+  
+  let rec traverse_partial_reduction (p : SHpure.t) (ptr_spat : (SHterm.t * (string * SHterm.t) list) list) (arr_spat : (SHterm.t * SHterm.t) list) (str_spat : (SHterm.t * SHterm.t) list) (_serialize : bool) (_print : bool) : SHpure.t = 
+    match p with
+    | Atom (_,_) -> eval_atom p
+    | Or xs -> 
+      let rec_traversal = (List.map(fun x -> (traverse_partial_reduction x ptr_spat arr_spat str_spat _serialize _print))xs) in
+      Or(rec_traversal)
+      (*if List.exists(fun x -> x = SHpure.True) rec_traversal then True else Or(List.filter(fun e -> e != SHpure.False)rec_traversal)*)
+    | And xs ->
+      let atoms, expr = List.partition(fun x -> match x with | SHpure.Atom (_, _) -> true |_ -> false) xs in
+      let simplify_atoms = if atoms != [] then (
+        let g = WDGraph.create () in
+        let _ = WDGraph.add_conjunctions g atoms in 
+        let _ = WDGraph.simplify g in
+        let _ = WDGraph.add_mem_spat g arr_spat str_spat ptr_spat in (* IMPORTANT first add array over pointers, otherwise will be hard to check for cycles of yellow edges to detect backward edges (src memory addres > dst memory adress ) *)
+        let _ = WDGraph.add_ptr g ptr_spat in
+        if _serialize then (
+          (*Fmt.printf "@[[Partial subformula]@.";
+          Fmt.printf "@[%a@." SHpure.pp SHpure.And(atoms);*)
+          let dot_g = DotSerializer.serialize_graph g in
+          Printf.printf "\nDot serialize graph:\n";
+          print_endline dot_g;
+          let dot_qg = DotSerializer.serialize_quotient_graph g in
+          Printf.printf "\nDot serialize quotient graph:\n";
+          print_endline dot_qg;
+        );
+        if _print then (
+          (*Fmt.printf "@[[Partial subformula]@.";
+          Fmt.printf "@[%a@." SHpure.pp SHpure.And(atoms);*)
+          Printf.printf "Graph Summary:\n";
+          TextPrinter.print_graph g;
+          Printf.printf "Quotient Graph Summary:\n";
+          TextPrinter.print_quotient_graph g;
+        );
+
+        WDGraph.get_partial_conjunctions_eval_atom g
+      ) else [] in
+      let simplify_expr = if expr != [] || simplify_atoms != [False] then List.map(fun x -> traverse_partial_reduction x ptr_spat arr_spat str_spat _serialize _print) expr else [] in (* Lazy eval *)
+      if simplify_atoms = [False] then False 
+      else if expr = [] && simplify_atoms = [] then True else And(simplify_atoms @ simplify_expr)
+    | _ -> failwith "ERROR: Unexpected formula structure during process_partial_conjunctions."
+
+  let partial_simplify_pure_spat (p : SHpure.t) (ss : SHspat.t) (_stats : bool) (_serialize : bool) (_print : bool) : SHpure.t =
+    let start_time_dnf = Unix.gettimeofday () in
+    let preprocess_p = partial_preprocess p in
+    let ptr_spat = SHspat.getPtrSeg ss in
+    let arr_spat = SHspat.getArraySeg ss in 
+    let str_spat = SHspat.getStringSeg ss in 
+    let end_time_dnf = Unix.gettimeofday () in
+    let elapsed_time_dnf = end_time_dnf -. start_time_dnf in
+    let _og_size = if _stats then shpure_atom_size p else -1 in
+    let _dnf_size = if _stats then shpure_atom_size preprocess_p else -1 in
+
+    let start_time_simplify = Unix.gettimeofday () in
+    let red_preprocess_p = match preprocess_p with |Atom(_,_) -> eval_atom preprocess_p |_ -> traverse_partial_reduction preprocess_p ptr_spat arr_spat str_spat _serialize _print in 
+    let end_time_simplify = Unix.gettimeofday () in
+    let elapsed_time_simplify = end_time_simplify -. start_time_simplify in
+    if _stats then (
+      Printf.printf "\nGENERAL STATS\n";
+      Printf.printf "Execution time preprocess conversion: %f seconds\n" elapsed_time_dnf;
+      Printf.printf "Size of Original formulae (atoms): %d\n" _og_size;
+      Printf.printf "Size of preprocess formulae (atoms): %d\n" _dnf_size;
+      Printf.printf "Execution time partial reduction: %f seconds\n" elapsed_time_simplify;
+      Printf.printf "Size of reduced formulae (atoms): %d\n\n" (shpure_atom_size red_preprocess_p);
+    );
+    red_preprocess_p
 ;;

--- a/simplifier/simplifier_main.ml
+++ b/simplifier/simplifier_main.ml
@@ -38,6 +38,7 @@ let _ucflag = ref false;;
 let _bnflag = ref false;;
 let _timeout = ref None;;
 let _stats = ref false;;
+let partial = ref false;;
 let f_help () = print_endline "help";;
 let set_filename fname = _fname := fname;;
 let set_raw () = _rawflag := true;;
@@ -46,6 +47,7 @@ let set_unsatcore () = _ucflag := true;;
 let set_foption opt = p_opt := opt :: !p_opt;;
 let set_timeout sec = _timeout := Some sec;;
 let set_stats () = _stats := true;;
+let set_partial () = _partial := true;;
   
 let msgUsage =
 "USAGE: simplifier [-d <TAG>|-b|-0|-t|-s] -f <filename>";;
@@ -60,6 +62,7 @@ let speclist = [
     ("-0", Arg.Unit set_raw, "Use raw z3 (Only checking the pure-part with Z3 ignoring the spat-part)");
     ("-t", Arg.Int set_timeout, "Set timeout [sec] (default:4294967295)");
     ("-s", Arg.Unit set_stats, "Reports execution stats (execution time for now)");
+
   ];;
 
 (* parser *)

--- a/simplifier/simplifier_main.ml
+++ b/simplifier/simplifier_main.ml
@@ -38,7 +38,7 @@ let _ucflag = ref false;;
 let _bnflag = ref false;;
 let _timeout = ref None;;
 let _stats = ref false;;
-let partial = ref false;;
+let _normalize = ref false;;
 let _serialize = ref false;;
 let _pretty_print = ref false;;
 let f_help () = print_endline "help";;
@@ -49,7 +49,7 @@ let set_unsatcore () = _ucflag := true;;
 let set_foption opt = p_opt := opt :: !p_opt;;
 let set_timeout sec = _timeout := Some sec;;
 let set_stats () = _stats := true;;
-let set_partial () = _partial := true;;
+let set_normalize () = _normalize := true;;
 let set_serialize () = _serialize := true;;
 let set_pretty_print () = _pretty_print := true;;
   
@@ -64,7 +64,7 @@ let speclist = [
       UC: produce & show unsatcore when an input is unsat
       MD: produce & show a model when an input is sat");
     ("-0", Arg.Unit set_raw, "Use raw z3 (Only checking the pure-part with Z3 ignoring the spat-part)");
-    ("-1", Arg.Unit set_partial, "Use partial application of reduction algorithm to conjunctions (input will not be normalized to DNF)");
+    ("-n", Arg.Unit set_normalize, "Use partial application of reduction algorithm to conjunctions (input will not be normalized to DNF)");
     ("-t", Arg.Int set_timeout, "Set timeout [sec] (default:4294967295)");
     ("-s", Arg.Unit set_stats, "Reports execution stats (execution time for now)");
     ("-g", Arg.Unit set_serialize, "Generates dot code to visualize graphs");
@@ -91,10 +91,18 @@ let () =
   Fmt.printf "@[[Spatial-formula]@.";
   Fmt.printf "@[%a@." SS.pp ss;
 
-  let p' = Simplifier.simplify_pure_spat p ss !_stats !_serialize !_pretty_print in
-
-  Fmt.printf "@[[Simplified formula]@.";
-  Fmt.printf "@[%a@." DisjSH.ppln p';
+  if !_normalize then (
+    let p' =  Simplifier.simplify_pure_spat p ss !_stats !_serialize !_pretty_print in
+    Fmt.printf "@[[Simplified formula]@.";
+    Fmt.printf "@[%a@." DisjSH.ppln p';
+  )
+  else (
+  let p' = Simplifier.partial_simplify_pure_spat p ss !_stats !_serialize !_pretty_print in
+    Fmt.printf "@[[Simplified formula]@.";
+    Fmt.printf "@[%a@." P.pp p'; 
+    Fmt.printf "@[&&@.";
+    Fmt.printf "@[%a@." SS.pp ss;
+  ) 
   
 (*  
   let (startMesRaw,ssMes) = if !_rawflag then ("RAW-MODE ","Ignored") else ("","") in

--- a/simplifier/wdgraph/wdg.ml
+++ b/simplifier/wdgraph/wdg.ml
@@ -58,7 +58,7 @@ module WDGraph = struct
     red_edges = [];
     eq_representative_pairs = [];
     unsat = false;
-    black_edges = Hashtbl.create 1;
+    black_edges = Hashtbl.create 32;
     n_scc = -1;
     f_scc = None;
     r_scc = None;
@@ -184,13 +184,12 @@ module WDGraph = struct
         let n_scc, f_scc = SCC.scc(g.graph) in
         g.n_scc <- n_scc;
         g.f_scc <- Some f_scc;
-        let black_pairs_in_same_scc = Hashtbl.fold (fun (u, v) _ acc -> acc || (f_scc u == f_scc v)) g.black_edges false in
+        let black_pairs_in_same_scc = Hashtbl.fold (fun (u, v) _ acc -> acc || try (f_scc u == f_scc v) with Not_found -> false) g.black_edges false in
         if black_pairs_in_same_scc then g.unsat <- true (* Black contradiction 2: Inside an SCC there exists 2 nodes that are equivalent and diferent at the same time: `x = y and y != x` *)
         else 
             (* Compute representatives for SCCs *)
             let scc_nodes = Hashtbl.create n_scc in
             G.iter_vertex (fun v -> Hashtbl.add scc_nodes (f_scc v) v) g.graph;
-            
             let representatives = Array.make n_scc (SHterm.Int 0) (* Placeholder initial value *) in
             for i = 0 to n_scc - 1 do
               let nodes = Hashtbl.find_all scc_nodes i in
@@ -273,6 +272,39 @@ module WDGraph = struct
       if List.exists(fun e -> e == SHpure.False) pure_atoms then (False, []) 
       else (SHpure.And (List.filter(fun e -> e != SHpure.True) pure_atoms), spat_atoms)
     )
+
+    let get_partial_conjunctions_eval_atom (g : t) : SHpure.t list = 
+      let eval_atom a =  (* Evaluate atoms if all information is known *)
+        match a with
+        |SHpure.Atom(Le, [Int x; Int y]) -> if x <= y then SHpure.True else SHpure.False
+        |SHpure.Atom(Lt, [Int x; Int y]) -> if x < y then SHpure.True else SHpure.False
+        |SHpure.Atom(Neq, [Int x; Int y]) -> if x != y then SHpure.True else SHpure.False
+        |SHpure.Atom(Eq, [Int x; Int y]) -> if x == y then SHpure.True else SHpure.False
+        |_ -> a
+      in 
+      if g.unsat then 
+        [False]
+      else (
+        let rb_atoms = ref [] in (* Red / Blue edges (Pure) *)
+        G.iter_edges_e (fun (u, w, v) -> 
+          match w with  (* Rebuild atoms or expresions from edges *)
+          | Red -> rb_atoms := eval_atom(SHpure.Atom(Lt, [u; v])) :: !rb_atoms
+          | Blue -> rb_atoms := eval_atom(SHpure.Atom(Le, [u; v])) :: !rb_atoms
+          | Yellow -> ()
+          | Orange -> ()
+          | Green _ -> ()
+          | _ -> failwith "ERROR rebuilding graph, edge label (color) not suported"
+        ) g.quotient_graph;
+        let black_atoms = Hashtbl.fold (fun (u, v) _ acc -> eval_atom(SHpure.Atom(Neq, [u; v])) :: acc ) g.black_edges [] in (* Rebuilding inequality edges *)
+        (* Rebuilding equality information *) 
+        let eq_atoms = List.map(fun (u, v) -> eval_atom(SHpure.Atom(Eq, [u; v]))) g.eq_representative_pairs in (*redundant information as the equalities are treated by representatives, adding it just for readability in final formula *)
+        let pure_atoms = eq_atoms @ !rb_atoms @ black_atoms in 
+        
+        if List.exists(fun e -> e == SHpure.False) pure_atoms then [False]
+        else 
+          let filtered_true_atoms = List.filter(fun e -> e != SHpure.True) pure_atoms in
+          if filtered_true_atoms = [] then [True] else filtered_true_atoms
+      )
 
   (* Add pointer edges in the quotient graph and evaluates any inconsistency *)
   let add_ptr (g : t) (ptr_spat : (SHterm.t * (string * SHterm.t) list) list) : unit =


### PR DESCRIPTION
Add partial simplification
Now partial simplification will be applied by default, thus the result will no longer be a `DisjSH` but just a pure and spatial part (without substitutions in the spatial part) 
Use flag `-n` no normalize the input into DNF